### PR TITLE
Add Get-GitHubTags cmdlet and modify the release process

### DIFF
--- a/.docs/CONTRIBUTING.md
+++ b/.docs/CONTRIBUTING.md
@@ -26,9 +26,9 @@ The first function will create/update all the Markdown help in the `.docs/Module
 See the example below for a guide on how to use these.
 
 ## Update the changelog  
-The changelog _must_ be updated for every pull request (even small changes), this is because the changelog is used to calculate the NuGet package manifest/version number.  
+The changelog _must_ be updated when making a release, this is because the changelog is used to calculate the NuGet package manifest/version number and release notes.   
 The changelog follows the [SemVer v1.0.0](https://semver.org/spec/v1.0.0.html) spec.  
-You can use the [`Update-Changelog`](.docs/Module/Public/Update-Changelog.md) cmdlet from this very module to make the changes for you, the cmdlet is fully guided and it will even offer to auto-generate the changelog entries based off of a list of commits from your branch 🙂
+You can use the [`Update-Changelog`](.docs/Module/Public/Update-Changelog.md) cmdlet from this very module to make the changes for you, the cmdlet is fully guided and it will even offer to auto-generate the changelog entries based off of a list of commits since the last release. 🪄🧙‍♂️
 
 ## Example
 Let's say we want to create a new cmdlet called `New-Cmdlet` and add it to the Brownserve.PSTools module, this cmdlet will in turn call `New-PrivateCmdlet` for some logic.  

--- a/.docs/Module/Brownserve.PSTools.md
+++ b/.docs/Module/Brownserve.PSTools.md
@@ -74,6 +74,9 @@ Obtains a NuGet package version based on the build version number and branch nam
 ### [New-PullRequest](New-PullRequest.md)
 Creates a new pull request in GitHub
 
+### [New-TempDirectory](New-TempDirectory.md)
+Creates a new temporary directory with a random name in the systems temporary directory
+
 ### [Publish-TeamcityArtifact](Publish-TeamcityArtifact.md)
 Tells Teamcity to export a given file/folder as an artifact.
 

--- a/.docs/Module/Public/Get-GitHubTags.md
+++ b/.docs/Module/Public/Get-GitHubTags.md
@@ -1,0 +1,89 @@
+---
+external help file: Brownserve.PSTools-help.xml
+Module Name: Brownserve.PSTools
+online version:
+schema: 2.0.0
+---
+
+# Get-GitHubTags
+
+## SYNOPSIS
+Gets a list of tags for a given GitHub repository
+
+## SYNTAX
+
+```
+Get-GitHubTags [-RepoName] <String> [-GitHubOrg] <String> -GitHubToken <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a list of tags for a given GitHub repository
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-GitHubTags -GitHubOrg 'myOrg' -GitHubToke $GitHubToken -RepoName 'myRepo'
+```
+
+This would fetch all the tags for the repository "myRepo" which lives in the GitHubOrg "myOrg"
+
+## PARAMETERS
+
+### -GitHubOrg
+The organisation/owner that houses the repository you wish to query
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GitHubOrganisation, GitHubOrganization
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GitHubToken
+The token with the relevant permissions to access the repository
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RepoName
+The name of the repo to query
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,4 @@ Thanks for submitting a PR to Brownserve.PSTools, please fill out the informatio
 ## Checklist
 Have you:
 - [ ] [Read the contributing guide](https://github.com/Brownserve-UK/Brownserve.PSTools/blob/main/.docs/CONTRIBUTING.md)
-- [ ] [Updated the Changelog](https://github.com/Brownserve-UK/Brownserve.PSTools/blob/main/.docs/CONTRIBUTING.md#update-the-changelog)
-- [ ] [Updated help documentation](https://github.com/Brownserve-UK/Brownserve.PSTools/blob/main/.docs/CONTRIBUTING.md#update-help-files) (if updating the module)
+- [ ] [Updated help documentation](https://github.com/Brownserve-UK/Brownserve.PSTools/blob/main/.docs/CONTRIBUTING.md#update-help-files) (if creating/updating a cmdlet)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 ---
 name: release
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    
 
 jobs: 
   release:

--- a/Module/Public/GitHub/Get-GitHubTags.ps1
+++ b/Module/Public/GitHub/Get-GitHubTags.ps1
@@ -1,0 +1,46 @@
+function Get-GitHubTags
+{
+    [CmdletBinding()]
+    param
+    (
+        # The GitHub repo to create the release against
+        [Parameter(
+            Mandatory = $true,
+            Position = 0
+        )]
+        [string]
+        $RepoName,
+
+        # The organisation that the repo lives in
+        [Parameter(
+            Mandatory = $true,
+            Position = 1
+        )]
+        [Alias('GitHubOrganisation','GitHubOrganization')]
+        [string]
+        $GitHubOrg,
+
+        # The PAT to access the repo
+        [Parameter(
+            Mandatory = $true
+        )]
+        [string]
+        $GitHubToken
+    )
+    $Header = @{                                                                                                                                         
+        Authorization = "token $GitHubToken"
+        Accept        = 'application/vnd.github.v3+json'
+    }
+    $URI = "https://api.github.com/repos/$GitHubOrg/$RepoName/tags"
+
+    Write-Verbose "Attempting to fetch tags from $URI"
+    try
+    {
+        $Request = Invoke-RestMethod -Headers $Header -Uri $URI -Method Get -FollowRelLink | Foreach-Object { $_ } # Needed because of https://github.com/PowerShell/PowerShell/issues/5526
+    }
+    catch
+    {
+        Write-Error $_.Exception.Message
+    }
+    Return $Request
+}

--- a/Module/en-US/Brownserve.PSTools-help.xml
+++ b/Module/en-US/Brownserve.PSTools-help.xml
@@ -541,6 +541,133 @@
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-GitHubTags</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>GitHubTags</command:noun>
+      <maml:description>
+        <maml:para>Gets a list of tags for a given GitHub repository</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets a list of tags for a given GitHub repository</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-GitHubTags</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>RepoName</maml:name>
+          <maml:description>
+            <maml:para>The name of the repo to query</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="GitHubOrganisation, GitHubOrganization">
+          <maml:name>GitHubOrg</maml:name>
+          <maml:description>
+            <maml:para>The organisation/owner that houses the repository you wish to query</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>GitHubToken</maml:name>
+          <maml:description>
+            <maml:para>The token with the relevant permissions to access the repository</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="GitHubOrganisation, GitHubOrganization">
+        <maml:name>GitHubOrg</maml:name>
+        <maml:description>
+          <maml:para>The organisation/owner that houses the repository you wish to query</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>GitHubToken</maml:name>
+        <maml:description>
+          <maml:para>The token with the relevant permissions to access the repository</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>RepoName</maml:name>
+        <maml:description>
+          <maml:para>The name of the repo to query</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Get-GitHubTags -GitHubOrg 'myOrg' -GitHubToke $GitHubToken -RepoName 'myRepo'</dev:code>
+        <dev:remarks>
+          <maml:para>This would fetch all the tags for the repository "myRepo" which lives in the GitHubOrg "myOrg"</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-OpenPullRequests</command:name>
       <command:verb>Get</command:verb>
       <command:noun>OpenPullRequests</command:noun>


### PR DESCRIPTION
This modifies the release process to make it a little bit more manual so that we can roll multiple changes into one release.