### PR TITLE
Replace command on Test-Administrator

### DIFF
--- a/Module/Public/Common/Test-Administrator.ps1
+++ b/Module/Public/Common/Test-Administrator.ps1
@@ -16,10 +16,8 @@ function Test-Administrator
             }
             'Linux|macOS'
             {
-                $WhoAmI = Start-SilentProcess `
-                    -FilePath 'whoami' `
-                    -PassThru | Select-Object -ExpandProperty 'OutputContent'
-                if ($WhoAmI -eq 'root')
+                $UID = & id -u
+                if ($UID -eq 0)
                 {
                     Return $true
                 }


### PR DESCRIPTION
This replaces the whoami check with UID check instead, this has the knock on effect of fixing #22 as it replaces the last use of `Start-SilentProcess`
