### PR TITLE
Refactor and rework the Invoke-NativeCommand cmdlet

### DIFF
--- a/.docs/Module/Public/Invoke-NativeCommand.md
+++ b/.docs/Module/Public/Invoke-NativeCommand.md
@@ -14,7 +14,7 @@ Invokes a native command while gracefully handling the output and error streams.
 
 ```
 Invoke-NativeCommand [-FilePath] <String> [[-ArgumentList] <Array>] [[-WorkingDirectory] <String>]
- [[-ExitCodes] <Array>] [-PassThru] [-SuppressOutput] [-RedirectOutputPath <String>]
+ [[-ExitCodes] <Array>] [-PassThru] [-SuppressOutput] [-RedirectOutput] [-RedirectOutputPath <String>]
  [-RedirectOutputPrefix <String>] [-RedirectOutputSuffix <String>] [<CommonParameters>]
 ```
 
@@ -108,10 +108,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RedirectOutput
+If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -RedirectOutputPath
 The path to where the redirected output should be stored
-Defaults to the contents of the global variable 'RepoLogDirectory' if available
-If that isn't set then defaults to a temp directory.  
+Defaults to the contents of the global variable '$global:RepoLogDirectory' if available
+If that isn't set then defaults to a file in the systems temp directory.  
 **This is only used when `-SuppressOutput` is specified**
 
 ```yaml
@@ -157,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -SuppressOutput
-If specified will suppress command output
+If specified will stop the command outputting to host, useful when running very verbose commands that can quickly fill up build logs etc.
 
 ```yaml
 Type: SwitchParameter

--- a/.docs/Module/Public/Invoke-NativeCommand.md
+++ b/.docs/Module/Public/Invoke-NativeCommand.md
@@ -14,8 +14,8 @@ Invokes a native command while gracefully handling the output and error streams.
 
 ```
 Invoke-NativeCommand [-FilePath] <String> [[-ArgumentList] <Array>] [[-WorkingDirectory] <String>]
- [[-ExitCodes] <Array>] [-PassThru] [-SuppressOutput] [-RedirectOutput] [-RedirectOutputPath <String>]
- [-RedirectOutputPrefix <String>] [-RedirectOutputSuffix <String>] [<CommonParameters>]
+ [[-ExitCodes] <Array>] [-PassThru] [-SuppressOutput] [-LogOutput] [-LogOutputPath <String>]
+ [-LogOutputPrefix <String>] [-LogOutputSuffix <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -93,74 +93,71 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -LogOutput
+If set will log the output of the command to disk
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogOutputPath
+The path to where the output should be logged (must be a directory)
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogOutputPrefix
+An optional prefix to add to the log file(s), if none is set then the name of the command being run is used
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogOutputSuffix
+The file extension to use for the log file (defaults to .log)
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PassThru
 Pass this parameter if you want the cmdlet to return a PowerShell object of the native commands output stream
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RedirectOutput
-If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RedirectOutputPath
-The path to where the redirected output should be stored
-Defaults to the contents of the global variable '$global:RepoLogDirectory' if available
-If that isn't set then defaults to a file in the systems temp directory.  
-**This is only used when `-SuppressOutput` is specified**
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RedirectOutputPrefix
-The prefix to use on the redirected streams, defaults to the command run time
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RedirectOutputSuffix
-The suffix for the redirected streams (defaults to log)
-
-```yaml
-Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/.docs/Module/Public/New-TerraformResourceBlock.md
+++ b/.docs/Module/Public/New-TerraformResourceBlock.md
@@ -152,9 +152,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-
 ### System.Management.Automation.PSObject
-
 ## OUTPUTS
 
 ### System.Object

--- a/Module/en-US/Brownserve.PSTools-help.xml
+++ b/Module/en-US/Brownserve.PSTools-help.xml
@@ -1973,9 +1973,20 @@ As many native commands can write verbose/logging information to stderr this cmd
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>RedirectOutput</maml:name>
+          <maml:description>
+            <maml:para>If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>RedirectOutputPath</maml:name>
           <maml:description>
-            <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable 'RepoLogDirectory' if available If that isn't set then defaults to a temp directory.
+            <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable '$global:RepoLogDirectory' if available If that isn't set then defaults to a file in the systems temp directory.
  This is only used when `-SuppressOutput` is specified</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -2012,7 +2023,7 @@ As many native commands can write verbose/logging information to stderr this cmd
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SuppressOutput</maml:name>
           <maml:description>
-            <maml:para>If specified will suppress command output</maml:para>
+            <maml:para>If specified will stop the command outputting to host, useful when running very verbose commands that can quickly fill up build logs etc.</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2072,9 +2083,21 @@ As many native commands can write verbose/logging information to stderr this cmd
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>RedirectOutput</maml:name>
+        <maml:description>
+          <maml:para>If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>RedirectOutputPath</maml:name>
         <maml:description>
-          <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable 'RepoLogDirectory' if available If that isn't set then defaults to a temp directory.
+          <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable '$global:RepoLogDirectory' if available If that isn't set then defaults to a file in the systems temp directory.
  This is only used when `-SuppressOutput` is specified</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
@@ -2111,7 +2134,7 @@ As many native commands can write verbose/logging information to stderr this cmd
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SuppressOutput</maml:name>
         <maml:description>
-          <maml:para>If specified will suppress command output</maml:para>
+          <maml:para>If specified will stop the command outputting to host, useful when running very verbose commands that can quickly fill up build logs etc.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2439,7 +2462,7 @@ As many native commands can write verbose/logging information to stderr this cmd
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Performs a `terraform init` using Start-SilentProcess to suppress the output</maml:para>
+      <maml:para>Performs a `terraform init` using Invoke-NativeCommand to suppress the output</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>

--- a/Module/en-US/Brownserve.PSTools-help.xml
+++ b/Module/en-US/Brownserve.PSTools-help.xml
@@ -1962,6 +1962,53 @@ As many native commands can write verbose/logging information to stderr this cmd
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>LogOutput</maml:name>
+          <maml:description>
+            <maml:para>If set will log the output of the command to disk</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>LogOutputPath</maml:name>
+          <maml:description>
+            <maml:para>The path to where the output should be logged (must be a directory)</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>LogOutputPrefix</maml:name>
+          <maml:description>
+            <maml:para>An optional prefix to add to the log file(s), if none is set then the name of the command being run is used</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>LogOutputSuffix</maml:name>
+          <maml:description>
+            <maml:para>The file extension to use for the log file (defaults to .log)</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PassThru</maml:name>
           <maml:description>
             <maml:para>Pass this parameter if you want the cmdlet to return a PowerShell object of the native commands output stream</maml:para>
@@ -1971,54 +2018,6 @@ As many native commands can write verbose/logging information to stderr this cmd
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>RedirectOutput</maml:name>
-          <maml:description>
-            <maml:para>If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>RedirectOutputPath</maml:name>
-          <maml:description>
-            <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable '$global:RepoLogDirectory' if available If that isn't set then defaults to a file in the systems temp directory.
- This is only used when `-SuppressOutput` is specified</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>RedirectOutputPrefix</maml:name>
-          <maml:description>
-            <maml:para>The prefix to use on the redirected streams, defaults to the command run time</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>RedirectOutputSuffix</maml:name>
-          <maml:description>
-            <maml:para>The suffix for the redirected streams (defaults to log)</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SuppressOutput</maml:name>
@@ -2071,6 +2070,54 @@ As many native commands can write verbose/logging information to stderr this cmd
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>LogOutput</maml:name>
+        <maml:description>
+          <maml:para>If set will log the output of the command to disk</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>LogOutputPath</maml:name>
+        <maml:description>
+          <maml:para>The path to where the output should be logged (must be a directory)</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>LogOutputPrefix</maml:name>
+        <maml:description>
+          <maml:para>An optional prefix to add to the log file(s), if none is set then the name of the command being run is used</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>LogOutputSuffix</maml:name>
+        <maml:description>
+          <maml:para>The file extension to use for the log file (defaults to .log)</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>PassThru</maml:name>
         <maml:description>
           <maml:para>Pass this parameter if you want the cmdlet to return a PowerShell object of the native commands output stream</maml:para>
@@ -2081,55 +2128,6 @@ As many native commands can write verbose/logging information to stderr this cmd
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>RedirectOutput</maml:name>
-        <maml:description>
-          <maml:para>If specified this will cause the output from the command to be redirect to disk, useful when you may want to inspect the output later on (e.g. during builds)</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>RedirectOutputPath</maml:name>
-        <maml:description>
-          <maml:para>The path to where the redirected output should be stored Defaults to the contents of the global variable '$global:RepoLogDirectory' if available If that isn't set then defaults to a file in the systems temp directory.
- This is only used when `-SuppressOutput` is specified</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>RedirectOutputPrefix</maml:name>
-        <maml:description>
-          <maml:para>The prefix to use on the redirected streams, defaults to the command run time</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>RedirectOutputSuffix</maml:name>
-        <maml:description>
-          <maml:para>The suffix for the redirected streams (defaults to log)</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SuppressOutput</maml:name>


### PR DESCRIPTION
This PR reworks the Invoke-NativeCommand cmdlet to make it a little more secure.

Now it will no longer redirect output to disk unless explicitly requested by the user.

The return of the cmdlet has also been tweaked slightly so that it returns all output from any stream alongside individual streams for greater flexibility.