### PR TITLE
Add Add-GitHubReleaseAsset cmdlet

### DIFF
--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -859,9 +859,11 @@ task Tests ImportModule, UpdateModuleDocumentation, {
     Creates a NuGet package for the module
 .DESCRIPTION
     This prepares all the files required to ship a NuGet package.
+    Because we upload a NuGet package to both nuget.org _and_ GitHub we need to ensure we run this task if either of
+    those endpoints are targetted.
 #>
 task PrepareNuGetPackage SetVersion, CreateModuleManifest, FormatReleaseNotes, CreateModuleHelp, {
-    if ('nuget' -in $PublishTo)
+    if (('nuget' -in $PublishTo) -or ('GitHub' -in $PublishTo))
     {
         # We'll copy our build module to the nuget package and rename it to 'tools' 
         # as that seems to be the right way to do things

--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -658,6 +658,31 @@ task CreateModuleHelp UpdateModuleDocumentation, {
 
 <#
 .SYNOPSIS
+    Compress the module so it can be uploaded to GitHub
+.DESCRIPTION
+#>
+task CompressModule CreateModuleHelp, {
+    if ('GitHub' -in $PublishTo)
+    {
+        $script:CompressedModule = Join-Path $global:BrownserveRepoBuildOutputDirectory "Brownserve.PSTools-$($Global:BuildVersion).tgz"
+        Write-Build White 'Compressing PowerShell module'
+        try
+        {
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($global:BrownserveBuiltModuleDirectory, $script:CompressedModule)
+        }
+        catch
+        {
+            throw "Failed to compress module.`n$($_.Exception.Message)"
+        }
+    }
+    else
+    {
+        Write-Verbose 'GitHub not targetted, skipping creation of compressed module asset'
+    }
+}
+
+<#
+.SYNOPSIS
     Ensures line endings for tracked files are set to 'LF'
 .DESCRIPTION
     PowerShell seems to insist on doing inconsistent things with line endings when running on different OSes.
@@ -884,10 +909,12 @@ task PrepareNuGetPackage SetVersion, CreateModuleManifest, FormatReleaseNotes, C
 .SYNOPSIS
     Packs the nuget package ready for shipping off to nuget.org (or a private feed)
 .DESCRIPTION
-    Runs `nuget pack` to create a NuGet package of the module (but only if we're publishing to a NuGet feed)
+    Runs `nuget pack` to create a NuGet package of the module.
+    We upload this to both nuget.org _and_ GitHub as a release asset so we need to make sure we do this if either is
+    targetted
 #>
 task PackNuGetPackage PrepareNuGetPackage, {
-    if ('nuget' -in $PublishTo)
+    if (('nuget' -in $PublishTo) -or ('GitHub' -in $PublishTo))
     {
         Write-Build White 'Creating NuGet package'
         exec {
@@ -909,11 +936,11 @@ task PackNuGetPackage PrepareNuGetPackage, {
             }
             & $NugetCommand $NugetArguments
         }
-        $script:nupkgPath = Join-Path $Global:BrownserveRepoBuildOutputDirectory "$ModuleName.$global:BuildVersion.nupkg" | Convert-Path
+        $script:nupkgPath = Join-Path $Global:BrownserveRepoBuildOutputDirectory "$ModuleName-$global:BuildVersion.nupkg" | Convert-Path
     }
     else
     {
-        Write-Verbose 'Nuget not targeted, skipping...'
+        Write-Verbose 'Nuget and GitHub not targeted, skipping...'
     }
 }
 
@@ -924,7 +951,7 @@ task PackNuGetPackage PrepareNuGetPackage, {
     This task pushes the release up to the various endpoints we target.
     Endpoints can be configured in the $PublishTo parameter
 #>
-task PublishRelease CheckPreviousReleases, Tests, PackNuGetPackage, CheckForUncommittedChanges, {
+task PublishRelease CheckPreviousReleases, CompressModule, Tests, PackNuGetPackage, CheckForUncommittedChanges, {
     # Only push to nuget if we want to
     if ('nuget' -in $PublishTo)
     {
@@ -987,7 +1014,26 @@ task PublishRelease CheckPreviousReleases, Tests, PackNuGetPackage, CheckForUnco
             $ReleaseParams.Add('Prerelease', $true)
             $ReleaseParams.Add('TargetCommit', $script:CurrentCommitHash)
         }
-        New-GitHubRelease @ReleaseParams | Out-Null
+        $ReleaseResponse = New-GitHubRelease @ReleaseParams
+        
+        if ($script:CompressedModule)
+        {
+            Write-Build White 'Uploading compressed module as release asset'
+            Add-GitHubReleaseAsset `
+                -UploadURL = $ReleaseResponse.upload_url `
+                -Token $GitHubReleaseToken `
+                -FilePath $script:CompressedModule `
+                -ErrorAction 'Stop'
+        }
+        if ($script:nupkgPath)
+        {
+            Write-Build White 'Uploading nupkg as release asset'
+            Add-GitHubReleaseAsset `
+                -UploadURL = $ReleaseResponse.upload_url `
+                -Token $GitHubReleaseToken `
+                -FilePath $script:nupkgPath `
+                -ErrorAction 'Stop'
+        }
     }
     else
     {

--- a/Docs/Brownserve.PSTools.md
+++ b/Docs/Brownserve.PSTools.md
@@ -21,6 +21,9 @@ Inserts a new changelog entry into a given changelog file
 ### [Add-GitChanges](./Brownserve.PSTools/Add-GitChanges.md)
 This cmdlet is a wrapper for the git command 'git add \<path\>'.
 
+### [Add-GitHubReleaseAsset](./Brownserve.PSTools/Add-GitHubReleaseAsset.md)
+Uploads a file to a GitHub release.
+
 ### [Add-ModuleHelp](./Brownserve.PSTools/Add-ModuleHelp.md)
 Creates XML MALM help for a PowerShell module
 

--- a/Docs/Brownserve.PSTools/Add-GitHubReleaseAsset.md
+++ b/Docs/Brownserve.PSTools/Add-GitHubReleaseAsset.md
@@ -1,0 +1,158 @@
+---
+external help file: Brownserve.PSTools-help.xml
+Module Name: Brownserve.PSTools
+online version:
+schema: 2.0.0
+---
+
+# Add-GitHubReleaseAsset
+
+## SYNOPSIS
+Uploads a file to a GitHub release.
+
+## SYNTAX
+
+```
+Add-GitHubReleaseAsset [-FilePath] <String> [[-AssetName] <String>] [[-AssetLabel] <String>]
+ [-UploadUrl] <String> [-Token] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This will upload a local file to a given GitHub release.
+
+## EXAMPLES
+
+### Example 1: Upload a file
+```powershell
+$ReleaseInfo = Get-GitHubRelease `
+  -RepositoryOwner 'Brownserve-UK' `
+  -RepositoryName 'Brownserve.PSTools' `
+  -Token $token | Select-Object -First 1
+Add-GitHubReleaseAsset `
+  -FilePath C:\myFile.zip `
+  -UploadURL $ReleaseInfo.upload_url `
+  -Token $token
+```
+
+This would upload the release asset `myFile.zip` to the latest release on the `Brownserve.PSTools` repository
+
+### Example 2: Use a custom name for the release asset
+```powershell
+$ReleaseInfo = Get-GitHubRelease `
+  -RepositoryOwner 'Brownserve-UK' `
+  -RepositoryName 'Brownserve.PSTools' `
+  -Token $token | Select-Object -First 1
+Add-GitHubReleaseAsset `
+  -FilePath C:\myFile.zip `
+  -AssetName 'PowerShellModule.zip'`
+  -UploadURL $ReleaseInfo.upload_url `
+  -Token $token
+```
+
+This would upload the release asset `myFile.zip` as `PowerShellModule.zip` to the latest release on the `Brownserve.PSTools` repository
+
+### Example 3: Use a label for the asset name
+```powershell
+$ReleaseInfo = Get-GitHubRelease `
+  -RepositoryOwner 'Brownserve-UK' `
+  -RepositoryName 'Brownserve.PSTools' `
+  -Token $token | Select-Object -First 1
+Add-GitHubReleaseAsset `
+  -FilePath C:\myFile.zip `
+  -AssetLabel 'Compressed PowerShell module'`
+  -UploadURL $ReleaseInfo.upload_url `
+  -Token $token
+```
+
+This would upload the release asset `myFile.zip` as `Compressed PowerShell module` to the latest release on the `Brownserve.PSTools` repository
+
+## PARAMETERS
+
+### -AssetLabel
+An optional label for the asset, used in place of the file name when displaying the asset on the GitHub release page however the name of the downloaded file remains the same as passed to the `-AssetName` parameter.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -AssetName
+Determines the name of the asset on GitHub.  
+Defaults to the name of the file passed to `-FilePath`
+**Remember to include the file extension if setting this manually**
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -FilePath
+The path to the file to upload.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Token
+The GitHub API token to use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UploadUrl
+The upload URL for the release.  
+This can be acquired via `Get-GitHubRelease`
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Brownserve.PSTools/Get-GitHubRelease.md
+++ b/Docs/Brownserve.PSTools/Get-GitHubRelease.md
@@ -13,7 +13,7 @@ Gets a list of releases from a given GitHub repo
 ## SYNTAX
 
 ```
-Get-GitHubRelease [-RepoName] <String> [-GitHubOrg] <String> -GitHubToken <String> [<CommonParameters>]
+Get-GitHubRelease [-RepositoryOwner] <String> [-RepositoryName] <String> [-Token] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,48 +33,48 @@ Would get all releases from the `Acme/MyRepo` repository
 
 ## PARAMETERS
 
-### -GitHubOrg
-The GitHub org/user that owns the repository
+### -RepositoryName
+The name of the repository to query for releases
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: GitHubOrganisation, GitHubOrganization
+Aliases: RepoName
 
 Required: True
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -GitHubToken
-The PAT to access the repo
+### -RepositoryOwner
+The owner of the repository
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RepoName
-The GitHub repo to create the release against
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
+Aliases: GitHubOrganisation, GitHubOrganization, GitHubOrg
 
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Token
+GitHub access token
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GitHubToken, GitHubPAT
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 ## OUTPUTS
 
 ### System.Object

--- a/Module/Public/GitHub/Add-GitHubReleaseAsset.ps1
+++ b/Module/Public/GitHub/Add-GitHubReleaseAsset.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Uploads a file to a GitHub release.
+.DESCRIPTION
+    Uploads a file to a GitHub release.
+#>
+function Add-GitHubReleaseAsset
+{
+    [CmdletBinding()]
+    param
+    (
+        # The path to the file to upload.
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 0
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $FilePath,
+
+        # Determines the name of the asset on GitHub (remember to include the extension!)
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 1
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $AssetName = (Split-Path $FilePath -Leaf),
+
+        # An optional label for the asset, used in place of the file name.
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 2
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $AssetLabel,
+
+        # The upload URL for the release.
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 3
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $UploadUrl,
+
+        # The GitHub API token to use.
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true,
+            Position = 4
+        )]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Token
+    )
+    begin
+    {
+    }
+    process
+    {
+        $Headers = @{
+            Accept                 = 'application/vnd.github+json'
+            Authorization          = "Bearer $Token"
+            'X-GitHub-Api-Version' = '2022-11-28'
+            'Content-Type'         = 'application/octet-stream' #TODO: Should this be hardcoded?
+        }
+
+        try
+        {
+            $FileToUpload = Get-Item $FilePath -Force -ErrorAction Stop
+        }
+        catch
+        {
+            throw "Unable to find file '$FilePath'."
+        }
+
+        <#
+            By default the `upload_url` property returned by the releases API looks like
+            https://uploads.github.com/repos/[OWNER]/[REPO]/releases/[RELEASE_ID]/assets{?name,label}
+            If we're using that URL then we need to chop off the end of it
+        #>
+        if ($UploadUrl -match '\{\?.*\}')
+        {
+            $UploadUrl = $UploadUrl | Split-Path
+        }
+        $UploadUrl += "/assets?name=$AssetName"
+        if ($AssetLabel)
+        {
+            $UploadUrl += "&label=$AssetLabel"
+        }
+        $Form = @{
+            file = $FileToUpload
+        }
+
+        try
+        {
+            $Result = Invoke-RestMethod -Uri $UploadUrl -Method Post -Headers $Headers -Form $Form -ErrorAction Stop
+        }
+        catch
+        {
+            throw "Unable to upload file '$FilePath' to '$UploadUrl'.`n$($_.Exception.Message)"
+        }
+    }
+    end
+    {
+        if ($Result)
+        {
+            return $Result
+        }
+        else
+        {
+            return $null
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability to upload GitHub release assets and modifies the build pipeline so that we do exactly that when targetting GitHub as a release repository by uploading a NuGet package and tgz of the module.

The latter might be redundant as we're providing a nupkg but we can revert that later if we so wish.

This also modifies the style of the Get-GitHubReleases cmdlet to make it consistent with our style.