### PR TITLE
Standardise GitHub cmdlet styling

### DIFF
--- a/Docs/Brownserve.PSTools/Get-GitHubTags.md
+++ b/Docs/Brownserve.PSTools/Get-GitHubTags.md
@@ -13,7 +13,7 @@ Gets a list of tags for a given GitHub repository
 ## SYNTAX
 
 ```
-Get-GitHubTags [-RepoName] <String> [-GitHubOrg] <String> -GitHubToken <String> [<CommonParameters>]
+Get-GitHubTags [-RepositoryName] <String> [-RepositoryOwner] <String> -Token <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,13 +30,28 @@ This would fetch all the tags for the repository "myRepo" which lives in the Git
 
 ## PARAMETERS
 
-### -GitHubOrg
-The organisation/owner that houses the repository you wish to query
+### -RepositoryName
+The name of the repository to query
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: GitHubOrganisation, GitHubOrganization
+Aliases: RepoName
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RepositoryOwner
+The owner of the repository to query
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GitHubOrganisation, GitHubOrganization, GitHubOrg
 
 Required: True
 Position: 1
@@ -45,31 +60,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -GitHubToken
-The token with the relevant permissions to access the repository
+### -Token
+The GitHub PAT
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: GitHubToken, GitHubPAT
 
 Required: True
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RepoName
-The name of the repo to query
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Brownserve.PSTools/New-GitHubRelease.md
+++ b/Docs/Brownserve.PSTools/New-GitHubRelease.md
@@ -13,8 +13,8 @@ Creates a release on GitHub
 ## SYNTAX
 
 ```
-New-GitHubRelease [-Name] <String> [-Tag] <String> [-Description] <String> [-RepoName] <String>
- [-GitHubOrg] <String> -GitHubToken <String> [-Prerelease] [-TargetCommit <String>] [<CommonParameters>]
+New-GitHubRelease [-Name] <String> [-Tag] <String> [-Description] <String> [-RepositoryName] <String>
+ [-RepositoryOwner] <String> -Token <String> [-Prerelease] [-TargetCommit <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -52,36 +52,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -GitHubOrg
-The GitHub org/user that owns the repository
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: GitHubOrganisation, GitHubOrganization
-
-Required: True
-Position: 4
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -GitHubToken
-The PAT to access the repo
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Name
 The name of the release
 
@@ -112,16 +82,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RepoName
-The GitHub repo to create the release against
+### -RepositoryName
+The name of the repository to create the release in
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: RepoName
 
 Required: True
 Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RepositoryOwner
+The owner of the repository to create the release in
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GitHubOrganisation, GitHubOrganization, GitHubOrg
+
+Required: True
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,6 +136,21 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+The GitHub PAT
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GitHubToken, GitHubPAT
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Module/Public/GitHub/Get-GitHubRelease.ps1
+++ b/Module/Public/GitHub/Get-GitHubRelease.ps1
@@ -37,7 +37,7 @@ function Get-GitHubRelease
     {}
     process
     {
-        $Header = @{                                                                                                                                         
+        $Header = @{
             Authorization = "token $Token"
             Accept        = 'application/vnd.github.v3+json'
         }

--- a/Module/Public/GitHub/Get-GitHubTags.ps1
+++ b/Module/Public/GitHub/Get-GitHubTags.ps1
@@ -8,39 +8,49 @@ function Get-GitHubTags
             Mandatory = $true,
             Position = 0
         )]
+        [Alias('RepoName')]
         [string]
-        $RepoName,
+        $RepositoryName,
 
         # The organisation that the repo lives in
         [Parameter(
             Mandatory = $true,
             Position = 1
         )]
-        [Alias('GitHubOrganisation','GitHubOrganization')]
+        [Alias('GitHubOrganisation', 'GitHubOrganization', 'GitHubOrg')]
         [string]
-        $GitHubOrg,
+        $RepositoryOwner,
 
         # The PAT to access the repo
         [Parameter(
             Mandatory = $true
         )]
+        [Alias('GitHubToken', 'GitHubPAT')]
         [string]
-        $GitHubToken
+        $Token
     )
-    $Header = @{                                                                                                                                         
-        Authorization = "token $GitHubToken"
-        Accept        = 'application/vnd.github.v3+json'
-    }
-    $URI = "https://api.github.com/repos/$GitHubOrg/$RepoName/tags"
+    begin
+    {}
+    process
+    {
+        $Header = @{
+            Authorization = "token $Token"
+            Accept        = 'application/vnd.github.v3+json'
+        }
+        $URI = "https://api.github.com/repos/$RepositoryOwner/$RepositoryName/tags"
 
-    Write-Verbose "Attempting to fetch tags from $URI"
-    try
-    {
-        $Request = Invoke-RestMethod -Headers $Header -Uri $URI -Method Get -FollowRelLink | Foreach-Object { $_ } # Needed because of https://github.com/PowerShell/PowerShell/issues/5526
+        Write-Verbose "Attempting to fetch tags from $URI"
+        try
+        {
+            $Request = Invoke-RestMethod -Headers $Header -Uri $URI -Method Get -FollowRelLink | ForEach-Object { $_ } # Needed because of https://github.com/PowerShell/PowerShell/issues/5526
+        }
+        catch
+        {
+            Write-Error $_.Exception.Message
+        }
     }
-    catch
+    end
     {
-        Write-Error $_.Exception.Message
+        Return $Request
     }
-    Return $Request
 }


### PR DESCRIPTION
Many of these cmdlets pre-dated this module and as such didn't match the style of the module.

They've all been updated to include:
* `begin/process/end` blocks
* `GitHub` in the cmdlet name
* Standard naming for common parameters (e.g. `RepositoryOwner`, `Token` etc)