### PR TITLE
check dotnet has at least one SDK installed so `dotnet new` will work

### DIFF
--- a/Module/Private/Build/Compare-BrownserveRepository.ps1
+++ b/Module/Private/Build/Compare-BrownserveRepository.ps1
@@ -82,6 +82,14 @@ function Compare-BrownserveRepository
             $RequiredTools = @('dotnet')
             Write-Verbose 'Checking for required tooling'
             Assert-Command $RequiredTools
+
+            # Just having dotnet isn't enough, we need to ensure at least one SDK is installed
+            # Otherwise `dotnet new` won't work
+            $DotNetSDKs = & dotnet --list-sdks
+            if (-not $DotNetSDKs)
+            {
+                throw "No .NET SDKs are installed. Please install a .NET SDK to continue."
+            }
         }
         catch
         {


### PR DESCRIPTION
Caught on a new W11 device that has dotnet 8 installed but didn't have any sdk's