### PR TITLE
ops: update Slack webhook build secret name

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -29,7 +29,7 @@ jobs:
         shell: pwsh
         if: ${{ always() }}
         env:
-          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BUILD }}
           BUILD_BRANCH: ${{ github.head_ref }}
         run: |
             ./Brownserve.PSTools/.build/_init.ps1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         shell: pwsh
         if: ${{ always() }}
         env:
-          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BUILD }}
           BUILD_BRANCH: ${{ github.ref }}
         run: |
             ./Brownserve.PSTools/.build/_init.ps1

--- a/.github/workflows/stage-release.yaml
+++ b/.github/workflows/stage-release.yaml
@@ -65,7 +65,7 @@ jobs:
         shell: pwsh
         if: ${{ always() }}
         env:
-          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BUILD_NOTIFICATION_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_BUILD }}
           BUILD_BRANCH: ${{ github.ref }}
         run: |
             ./Brownserve.PSTools/.build/_init.ps1


### PR DESCRIPTION
The secret name changed at the org level and needed updating in our workflows