### PR TITLE
fix: remove references to UpdateModulePageHelpVersion, we don't use this method anymore.

### DIFF
--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -1301,7 +1301,7 @@ task BuildTestAndCheck BuildAndTest, CheckForUncommittedChanges, {}
     This allows us to review the changes and make any adjustments before we actually release them.
     We use this task in the stage_release CI pipeline.
 #>
-task StageRelease CheckStagingParameters, SetStagingVariables, UseWorkingCopy, CreateChangelogEntry, UpdateChangelog, UpdateModuleDocumentation, UpdateModulePageHelpVersion, CreatePullRequest, {
+task StageRelease CheckStagingParameters, SetStagingVariables, UseWorkingCopy, CreateChangelogEntry, UpdateChangelog, UpdateModuleDocumentation, CreatePullRequest, {
     $BuildMessage = @"
 The release has been successfully staged and a pull request has been created.
 Please review the changes at $script:PRLink and merge if they look good.

--- a/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
+++ b/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
@@ -564,26 +564,6 @@ task UpdateModuleDocumentation ImportModule, {
 
 <#
 .SYNOPSIS
-    Update the module page help version to match the version we're releasing
-.DESCRIPTION
-    Due to some quirks of PlatyPS the help version can't currently be updated past it's initial version.
-    So we do this manually, but we only do it as part of the StageRelease build as the version doesn't really matter
-    until we're performing a release.
-    Yes that does mean people coming to the repo may see a mismatched version of the help files vs module version
-    however they should be going straight to the tagged release to get their documentation.
-    This will be mitigated if/when we move our Docs to a static site generator like GitHub pages.
-#>
-task UpdateModulePageHelpVersion SetVersion, UpdateModuleDocumentation, {
-    Write-Build White 'Updating module page help version'
-    Update-PlatyPSModulePageHelpVersion `
-        -HelpVersion $Global:BuildVersion `
-        -ModulePagePath $Script:ModulePagePath `
-        -ErrorAction 'Stop'
-    $script:TrackedFiles += $Script:ModulePagePath
-}
-
-<#
-.SYNOPSIS
     Updates the modules MALM help
 .DESCRIPTION
     PlatyPS will read in the markdown files in the 'Docs' directory and generate a MALM help file for the module.
@@ -978,7 +958,7 @@ task BuildTestAndCheck BuildAndTest, CheckForUncommittedChanges, {}
     This allows us to review the changes and make any adjustments before we actually release them.
     We use this task in the stage_release CI pipeline.
 #>
-task StageRelease CheckStagingParameters, CreateChangelogEntry, UpdateChangelog, UpdateModuleDocumentation, UpdateModulePageHelpVersion, SetLineEndings, CreatePullRequest, {
+task StageRelease CheckStagingParameters, CreateChangelogEntry, UpdateChangelog, UpdateModuleDocumentation, SetLineEndings, CreatePullRequest, {
     $BuildMessage = @"
 The release has been successfully staged and a pull request has been created.
 Please review the changes at $script:PRLink and merge if they look good.


### PR DESCRIPTION
We moved to using the `HelpVersion` parameter in https://github.com/Brownserve-UK/Brownserve.PSTools/pull/87/changes/35ae4fdb7cd55f204f9b80dd9c9b94be02767caf and removed this task so cleanup any old references to it...