### PR TITLE
fix: don't throw when we can't find a merge commit

### DIFF
--- a/Module/Public/Build/New-BrownserveChangelogEntry.ps1
+++ b/Module/Public/Build/New-BrownserveChangelogEntry.ps1
@@ -209,7 +209,9 @@ function New-BrownserveChangelogEntry
                 }
                 else
                 {
-                    throw "Failed to find pull request for merge commit '$MergeCommit'"
+                    # Not every merge commit corresponds to a PR: branch sync merges (e.g. "Merge branch 'main' into feature")
+                    # appear in git log but have no matching closed PR, so we skip them rather than throwing.
+                    Write-Verbose "Merge commit '$MergeCommit' has no corresponding pull request, skipping (likely a branch sync merge)"
                 }
             }
 

--- a/Module/Public/Build/New-BrownserveChangelogEntry.ps1
+++ b/Module/Public/Build/New-BrownserveChangelogEntry.ps1
@@ -211,7 +211,7 @@ function New-BrownserveChangelogEntry
                 {
                     # Not every merge commit corresponds to a PR: branch sync merges (e.g. "Merge branch 'main' into feature")
                     # appear in git log but have no matching closed PR, so we skip them rather than throwing.
-                    Write-Verbose "Merge commit '$MergeCommit' has no corresponding pull request, skipping (likely a branch sync merge)"
+                    Write-Warning "Merge commit '$MergeCommit' has no corresponding pull request, skipping (likely a branch sync merge)"
                 }
             }
 


### PR DESCRIPTION
Sometimes these are legit - e.g. merging branch `main` into an open PR.