### PR TITLE
ops: remove snippet-creator

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
         "streetsidesoftware.code-spell-checker",
         "ms-vscode.powershell",
         "yzhang.markdown-all-in-one",
-        "nikitakunevich.snippet-creator",
         "EditorConfig.EditorConfig",
         "DavidAnson.vscode-markdownlint"
       ],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "streetsidesoftware.code-spell-checker",
     "ms-vscode.powershell",
     "yzhang.markdown-all-in-one",
-    "nikitakunevich.snippet-creator",
     "EditorConfig.EditorConfig",
     "DavidAnson.vscode-markdownlint"
   ]


### PR DESCRIPTION
It's no longer maintained/supported and with AI now we probably don't need it anyways.

Resolves https://github.com/Brownserve-UK/Brownserve.PSTools/issues/78