### PR TITLE
ops: remove use of -UseWorkingCopy

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -22,7 +22,6 @@ jobs:
               -GitHubRepoName 'Brownserve.PSTools' `
               -BranchName $env:GITHUB_REF `
               -Build 'BuildTestAndCheck' `
-              -UseWorkingCopy `
               -Verbose
       # Step 3: Send a notification to Slack
       - name: notify-slack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,6 @@ jobs:
               -NugetFeedAPIKey $env:NugetFeedAPIKey `
               -PSGalleryAPIKey $env:PSGalleryAPIKey `
               -PublishTo ${{ inputs.publish_to }} `
-              -UseWorkingCopy `
               -Verbose
       # Step 5: Push a notification to Slack
       - name: notify-slack

--- a/.github/workflows/stage-release.yaml
+++ b/.github/workflows/stage-release.yaml
@@ -49,7 +49,6 @@ jobs:
               Build = 'StageRelease'
               GitHubStageReleaseToken = $env:GitHubPAT
               ReleaseType = '${{ inputs.release_type}}'
-              UseWorkingCopy = $true
               Verbose = $true
             }
             if ($env:ReleaseNotice) {

--- a/Module/Private/Build/templates/psmodule_github_builds.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_builds.yaml.template
@@ -22,7 +22,6 @@ jobs:
               -GitHubRepoName '###MODULE_NAME###' `
               -BranchName $env:GITHUB_REF `
               -Build 'BuildTestAndCheck' `
-              -UseWorkingCopy `
               -Verbose
       # Step 3: Send a notification to Slack
       - name: notify-slack

--- a/Module/Private/Build/templates/psmodule_github_release.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_release.yaml.template
@@ -44,7 +44,6 @@ jobs:
               -NugetFeedAPIKey $env:NugetFeedAPIKey `
               -PSGalleryAPIKey $env:PSGalleryAPIKey `
               -PublishTo ${{ inputs.publish_to }} `
-              -UseWorkingCopy `
               -Verbose
       # Step 5: Push a notification to Slack
       - name: notify-slack

--- a/Module/Private/Build/templates/psmodule_github_stage-release.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_stage-release.yaml.template
@@ -49,7 +49,6 @@ jobs:
               Build = 'StageRelease'
               GitHubStageReleaseToken = $env:GitHubPAT
               ReleaseType = '${{ inputs.release_type}}'
-              UseWorkingCopy = $true
               Verbose = $true
             }
             if ($env:ReleaseNotice) {


### PR DESCRIPTION
This was previously needed due to substantially changing the way we ran builds between module releases but now the new module is published we should be in the clear.

Resolves: https://github.com/Brownserve-UK/Brownserve.PSTools/issues/80