### PR TITLE
fix: NuGet license warning

### DIFF
--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -1004,6 +1004,7 @@ task PrepareNuGetPackage SetVersion, CreateModuleManifest, FormatReleaseNotes, C
     <version>$Global:BuildVersion</version>
     <authors>$ModuleAuthor</authors>
     <owners>Brownserve UK</owners>
+    <license type="file">LICENSE</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>$ModuleDescription</summary>
     <description>$ModuleDescription</description>


### PR DESCRIPTION
Tell NuGet the license comes in as a file to hopefully suppress the warning we get during build

Resolves https://github.com/Brownserve-UK/Brownserve.PSTools/issues/44