### PR TITLE
[cicd]: enable `UseWorkingCopy` for stage-release

### DIFF
--- a/.github/workflows/stage-release.yaml
+++ b/.github/workflows/stage-release.yaml
@@ -50,6 +50,7 @@ jobs:
               GitHubStageReleaseToken = $env:GitHubPAT
               ReleaseType = '${{ inputs.release_type}}'
               Verbose = $true
+              UseWorkingCopy = $true
             }
             if ($env:ReleaseNotice) {
               $Params.Add('ReleaseNotice', $env:ReleaseNotice)


### PR DESCRIPTION
Due to changes to the changelog logic we need to use the copy of the module from this repo