### PR TITLE
[sec]: ensure GitHub Token used for PR builds is `readonly`

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   BuildTestAndCheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # Step 1: Checkout the repo
       - name: checkout-module


### PR DESCRIPTION
This workflow simply builds and tests the module and therefore would never need write access to the repo so let's be explicit with the token permissions