### PR TITLE
[sec]: improve security of GitHub Actions workflows

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -5,15 +5,18 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   BuildTestAndCheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
       # Step 1: Checkout the repo
       - name: checkout-module
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: Brownserve.PSTools
       # Step 2: Run the build script

--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -12,15 +12,18 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   label-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
       pull-requests: write
     steps:
       - name: apply-changelog-label
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const COMMENT_MARKER = '<!-- changelog-label-check -->';

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,20 +9,23 @@ on:
         default: '"nuget", "PSGallery", "GitHub"'
         type: string
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # Step 1: Generate a short-lived token from the GitHub App
       - name: generate-app-token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.BROWNSERVE_CI_APP_ID }}
           private-key: ${{ secrets.BROWNSERVE_CI_APP_PRIVATE_KEY }}
       # Step 2: Checkout the repo
       - name: checkout-module
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: Brownserve.PSTools
       # Step 3: Install Mono (required to run NuGet.exe on Linux)

--- a/.github/workflows/stage-release.yaml
+++ b/.github/workflows/stage-release.yaml
@@ -17,20 +17,23 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   stage-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # Step 1: Generate a short-lived token from the GitHub App
       - name: generate-app-token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.BROWNSERVE_CI_APP_ID }}
           private-key: ${{ secrets.BROWNSERVE_CI_APP_PRIVATE_KEY }}
       # Step 2: Checkout the repo
       - name: checkout-module
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: Brownserve.PSTools
           # We need to fetch the full history so that we can determine the changelog entries from the previous release


### PR DESCRIPTION
- Use action SHA pinning
- permissions: {}: added at the workflow level as a deny-all default
- sensible timeouts set to avoid long running jobs