### PR TITLE
fix: module help version updater

### DIFF
--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -773,6 +773,10 @@ task UpdateModuleDocumentation ImportModule, {
         Resolve-Path to fail.
     #>
     $Script:ModulePagePath = Join-Path $Global:BrownserveRepoDocsDirectory "$ModuleName.md" | Resolve-Path
+    if ($script:Stage -eq $true)
+    {
+        $script:TrackedFiles += ($Script:ModulePagePath | Convert-Path)
+    }
 }
 
 <#


### PR DESCRIPTION
At some point I broke the logic that updates the `Help version` frontmatter property. This (hopefully) fixes that.