### PR TITLE
fix: limit PR tests

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "module/**"
+      - ".build/**"
+      - ".config/**"
+      - "pages/reference/**"
+      - "nuget.config"
 
 permissions: {}
 

--- a/Module/Private/Build/templates/psmodule_github_builds.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_builds.yaml.template
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "module/**"
+      - ".build/**"
+      - ".config/**"
+      - "pages/reference/**"
+      - "nuget.config"
 
 permissions: {}
 


### PR DESCRIPTION
We were triggering the tests on all PR's but we only need them to run when we've modified files we care about.

This also updates the template too.