### PR TITLE
cicd: limit builds

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -8,7 +8,31 @@ on:
 permissions: {}
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: check-relevant-changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files --jq '.files[].path')
+          if echo "$FILES" | grep -qE '^(module/|\.build/|\.config/|pages/reference/|nuget\.config$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No relevant files changed, skipping build"
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   BuildTestAndCheck:
+    needs: check-changes
+    if: needs.check-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/Module/Private/Build/templates/psmodule_github_builds.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_builds.yaml.template
@@ -8,7 +8,31 @@ on:
 permissions: {}
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: check-relevant-changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files --jq '.files[].path')
+          if echo "$FILES" | grep -qE '^(module/|\.build/|\.config/|pages/reference/|nuget\.config$)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No relevant files changed, skipping build"
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   BuildTestAndCheck:
+    needs: check-changes
+    if: needs.check-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
right now we run the build/test on all PR's but we only need to run these if certain files have changed. As we require status checks to pass we can't just ignore paths so we just bail out early if we don't care about the changed files.

Also updates the templates for PowerShell modules