### PR TITLE
fix: remove unused ReleaseNotice logic

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -66,13 +66,6 @@ param
     [string]
     $ReleaseType = 'minor',
 
-    # An optional release notice to include in the release
-    [Parameter(
-        Mandatory = $false
-    )]
-    [string]
-    $ReleaseNotice,
-
     # The various places to publish to
     [Parameter(
         Mandatory = $False
@@ -240,10 +233,6 @@ try
     if ($PublishTo)
     {
         $BuildParams.Add('PublishTo', $PublishTo)
-    }
-    if ($ReleaseNotice)
-    {
-        $BuildParams.Add('ReleaseNotice', $ReleaseNotice)
     }
     Write-Verbose "Invoking build: $Build"
     Invoke-Build @BuildParams -Verbose:($PSBoundParameters['Verbose'] -eq $true)

--- a/.build/tasks/build_tasks.ps1
+++ b/.build/tasks/build_tasks.ps1
@@ -52,13 +52,6 @@ param
     [string]
     $ReleaseType,
 
-    # An optional release notice to include in the release
-    [Parameter(
-        Mandatory = $false
-    )]
-    [string]
-    $ReleaseNotice,
-
     # The branch this is being built from
     [Parameter(
         Mandatory = $true
@@ -438,10 +431,6 @@ task CreateChangelogEntry SetVersion, {
         RepositoryName  = $GitHubRepoName
         ChangelogObject = $script:Changelog
         SinceVersion    = $script:CurrentVersion
-    }
-    if ($ReleaseNotice)
-    {
-        $NewChangelogEntryParams.Add('Notice', $ReleaseNotice)
     }
     if ($GitHubStageReleaseToken)
     {

--- a/.github/workflows/stage-release.yaml
+++ b/.github/workflows/stage-release.yaml
@@ -12,10 +12,6 @@ on:
           - major
           - minor
           - patch
-      notice:
-        description: 'An optional notice to display on this release'
-        required: false
-        type: string
 
 permissions: {}
 
@@ -44,7 +40,6 @@ jobs:
         shell: pwsh
         env:
           GitHubPAT: ${{ steps.app-token.outputs.token }}
-          ReleaseNotice: ${{ inputs.notice }}
         run: |
             $Params = @{
               BranchName = $env:GITHUB_REF
@@ -53,8 +48,5 @@ jobs:
               GitHubStageReleaseToken = $env:GitHubPAT
               ReleaseType = '${{ inputs.release_type}}'
               Verbose = $true
-            }
-            if ($env:ReleaseNotice) {
-              $Params.Add('ReleaseNotice', $env:ReleaseNotice)
             }
             ./Brownserve.PSTools/.build/build.ps1 @Params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.18.0](https://github.com/Brownserve-UK/Brownserve.PSTools/tree/v0.18.0) (2026-05-18)
 
-_
-
 ### Added
 
 - feat: add pester test templates for documentation in [#163](https://github.com/Brownserve-UK/Brownserve.PSTools/pull/163) by [@shoddyguard](https://github.com/shoddyguard)

--- a/Module/Private/Build/templates/psmodule_build_script.ps1.template
+++ b/Module/Private/Build/templates/psmodule_build_script.ps1.template
@@ -66,13 +66,6 @@ param
     [string]
     $ReleaseType = 'minor',
 
-    # An optional release notice to include in the release
-    [Parameter(
-        Mandatory = $false
-    )]
-    [string]
-    $ReleaseNotice,
-
     # The various places to publish to
     [Parameter(
         Mandatory = $False

--- a/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
+++ b/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
@@ -52,13 +52,6 @@ param
     [string]
     $ReleaseType,
 
-    # An optional release notice to include in the release
-    [Parameter(
-        Mandatory = $false
-    )]
-    [string]
-    $ReleaseNotice,
-
     # The branch this is being built from
     [Parameter(
         Mandatory = $true
@@ -411,10 +404,6 @@ task CreateChangelogEntry SetVersion, {
         RepositoryName  = $GitHubRepoName
         ChangelogObject = $script:Changelog
         SinceVersion    = $script:CurrentVersion
-    }
-    if ($ReleaseNotice)
-    {
-        $NewChangelogEntryParams.Add('Notice', $ReleaseNotice)
     }
     if ($GitHubStageReleaseToken)
     {

--- a/Module/Private/Build/templates/psmodule_github_stage-release.yaml.template
+++ b/Module/Private/Build/templates/psmodule_github_stage-release.yaml.template
@@ -12,10 +12,6 @@ on:
           - major
           - minor
           - patch
-      notice:
-        description: 'An optional notice to display on this release'
-        required: false
-        type: string
 
 permissions: {}
 
@@ -44,7 +40,6 @@ jobs:
         shell: pwsh
         env:
           GitHubPAT: ${{ steps.app-token.outputs.token }}
-          ReleaseNotice: ${{ inputs.notice }}
         run: |
             $Params = @{
               BranchName = $env:GITHUB_REF
@@ -53,8 +48,5 @@ jobs:
               GitHubStageReleaseToken = $env:GitHubPAT
               ReleaseType = '${{ inputs.release_type}}'
               Verbose = $true
-            }
-            if ($env:ReleaseNotice) {
-              $Params.Add('ReleaseNotice', $env:ReleaseNotice)
             }
             ./###MODULE_NAME###/.build/build.ps1 @Params


### PR DESCRIPTION
Hasn't been used in a while and therefore doesn't do anything. Cleans up a stray line in the CHANGELOG too