### PR TITLE
fix: get repo name programmatically

### DIFF
--- a/Module/Private/Build/templates/psmodule_build_script.ps1.template
+++ b/Module/Private/Build/templates/psmodule_build_script.ps1.template
@@ -89,7 +89,7 @@ param
     )]
     [ValidateNotNullOrEmpty()]
     [string]
-    $GitHubRepoName = 'Brownserve.PSTools',
+    $GitHubRepoName,
 
     # GitHub token used during the StageRelease build, must have the following permissions:
     #   * Read/Write pull requests
@@ -156,12 +156,6 @@ if (!$ModuleInfo)
         throw 'Failed to load module information.'
     }
     Write-Verbose "Loaded module information from ModuleInfo.json:`n$($ModuleInfo | Out-String)"
-}
-
-# Just in case...
-if (!$GitHubRepoName)
-{
-    throw 'GitHubRepoName is required.'
 }
 
 # Run the init script

--- a/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
+++ b/Module/Private/Build/templates/psmodule_build_tasks.ps1.template
@@ -85,11 +85,11 @@ param
 
     # The GitHub repo to publish the release to and used to fill in release details for Nuget/PSGallery
     [Parameter(
-        Mandatory = $true
+        Mandatory = $false
     )]
     [ValidateNotNullOrEmpty()]
     [string]
-    $GitHubRepoName,
+    $GitHubRepoName = $Global:BrownserveRepoName,
 
     # GitHub token used during the StageRelease build, must have the following permissions:
     #   * Read/Write pull requests
@@ -128,6 +128,11 @@ param
     [hashtable[]]
     $CustomNugetFeeds###USE_WORKING_COPY_PARAM###
 )
+# Just in case...
+if (!$GitHubRepoName)
+{
+    throw 'GitHubRepoName not set'
+}
 # Set up a bunch of variables that we'll use through the build, some of these are global as they're used in our tests too
 $global:BrownserveBuiltModuleDirectory = Join-Path $global:BrownserveRepoBuildOutputDirectory $ModuleName
 # Depending on how we got the branch name we may need to remove the full ref


### PR DESCRIPTION
We had hardcoded a value before (Which was actually incorrect). Move to a programmatic logic