### PR TITLE
fix: small fixes

### DIFF
--- a/Module/Private/Build/Compare-BrownserveRepository.ps1
+++ b/Module/Private/Build/Compare-BrownserveRepository.ps1
@@ -1636,7 +1636,7 @@ function Compare-BrownserveRepository
         if ($IncludeMkDocs)
         {
             $PagesDirectory          = Join-Path $RepositoryPath 'pages'
-            $PagesReferenceDirectory = Join-Path $PagesDirectory 'reference'
+            $PagesReferenceDirectory = Join-Path $PagesDirectory 'Cmdlet reference'
             $PagesModuleDirectory    = Join-Path $PagesReferenceDirectory $ModuleInfo.Name
 
             foreach ($Dir in @($PagesDirectory, $PagesReferenceDirectory, $PagesModuleDirectory))

--- a/Module/Private/PowerShell/Classes.ps1
+++ b/Module/Private/PowerShell/Classes.ps1
@@ -10,11 +10,14 @@ class BrownservePowerShellModule
         $RequiredKeys = @('name','description','guid','tags')
         foreach ($Key in $RequiredKeys)
         {
-            if (!$Hashtable.$Key)
+            # ConvertFrom-Json -AsHashtable returns a case-sensitive hashtable in PS7,
+            # so find the matching key case-insensitively.
+            $MatchingKey = $Hashtable.Keys | Where-Object { $_ -ieq $Key } | Select-Object -First 1
+            if (!$MatchingKey)
             {
-                "Hashtable missing key '$Key'"
+                throw "Hashtable missing required key '$Key'"
             }
-            $this.$Key = $Hashtable.$Key
+            $this.$Key = $Hashtable[$MatchingKey]
         }
     }
 }


### PR DESCRIPTION
Ensure `BrownservePowerShellModule` is case insensitive. Ensure `Compare-BrownserveRepository` uses the right directory