### PR TITLE
fix: empty repo logic

### DIFF
--- a/Module/Private/Build/Compare-BrownserveRepository.ps1
+++ b/Module/Private/Build/Compare-BrownserveRepository.ps1
@@ -1637,9 +1637,8 @@ function Compare-BrownserveRepository
         {
             $PagesDirectory          = Join-Path $RepositoryPath 'pages'
             $PagesReferenceDirectory = Join-Path $PagesDirectory 'Cmdlet reference'
-            $PagesModuleDirectory    = Join-Path $PagesReferenceDirectory $ModuleInfo.Name
 
-            foreach ($Dir in @($PagesDirectory, $PagesReferenceDirectory, $PagesModuleDirectory))
+            foreach ($Dir in @($PagesDirectory, $PagesReferenceDirectory))
             {
                 if (!(Test-Path $Dir) -and ($MissingDirectories.Path -notcontains $Dir))
                 {
@@ -1663,7 +1662,7 @@ function Compare-BrownserveRepository
                 @{ Path = (Join-Path $RepositoryPath 'mkdocs.yml');                          Content = $NewMkDocsConfigContent },
                 @{ Path = (Join-Path $RepositoryPath 'requirements.txt');                    Content = $NewMkDocsRequirementsContent },
                 @{ Path = (Join-Path $PagesDirectory 'index.md');                            Content = $NewMkDocsIndexContent },
-                @{ Path = (Join-Path $PagesModuleDirectory '.pages');                        Content = $NewMkDocsPagesContent }
+                @{ Path = (Join-Path $PagesReferenceDirectory '.pages');                     Content = $NewMkDocsPagesContent }
             )
 
             foreach ($MkDocsFile in $MkDocsFiles)

--- a/Module/Private/Build/New-MkDocsPagesFile.ps1
+++ b/Module/Private/Build/New-MkDocsPagesFile.ps1
@@ -4,6 +4,6 @@ function New-MkDocsPagesFile
     param()
     process
     {
-        return 'order: asc'
+        return "title: Module Reference`nnav:`n  - Commands: Commands.md`n  - ..."
     }
 }

--- a/Module/Public/Build/New-BrownserveChangelogEntry.ps1
+++ b/Module/Public/Build/New-BrownserveChangelogEntry.ps1
@@ -202,10 +202,23 @@ function New-BrownserveChangelogEntry
         {
             try
             {
-                $MergesSinceLastRelease = Get-GitMerges `
-                    -RepositoryPath $ChangelogPath `
-                    -ReferenceBranch "v$($LastReleasedVersion.Version)" `
-                    -ErrorAction 'Stop'
+                $GetGitMergesParams = @{
+                    RepositoryPath = $ChangelogPath
+                    ErrorAction    = 'Stop'
+                }
+                <#
+                    When the changelog contains only the 0.0.0 placeholder entry seeded by
+                    Initialize-BrownserveRepository, no corresponding git tag exists. Passing it
+                    as a reference range to git would fail with "unknown revision or path not in
+                    the working tree". For a first release we want all merges from the beginning
+                    of the repo, so we omit ReferenceBranch. Get-GitMerges already handles this
+                    case by falling back to all-history mode when no ReferenceBranch is given.
+                #>
+                if (-not $ChangelogObject.HasPlaceholder)
+                {
+                    $GetGitMergesParams['ReferenceBranch'] = "v$($LastReleasedVersion.Version)"
+                }
+                $MergesSinceLastRelease = Get-GitMerges @GetGitMergesParams
                 if (!$MergesSinceLastRelease)
                 {
                     throw 'No merges found since last release'


### PR DESCRIPTION
When creating a new repo some bits weren't getting set-up correctly. This fixes that.